### PR TITLE
Ensure sender and recipient names are preserved

### DIFF
--- a/lib/mailgun/deliverer.rb
+++ b/lib/mailgun/deliverer.rb
@@ -36,7 +36,7 @@ module Mailgun
     end
 
     def build_basic_mailgun_message_for(rails_message)
-      {:from => rails_message.from, :to => rails_message.to, :subject => rails_message.subject,
+      {:from => rails_message[:from].formatted, :to => rails_message[:to].formatted, :subject => rails_message.subject,
        :html => extract_html(rails_message), :text => extract_text(rails_message)}
     end
 

--- a/spec/lib/mailgun/deliverer_spec.rb
+++ b/spec/lib/mailgun/deliverer_spec.rb
@@ -34,6 +34,10 @@ describe Mailgun::Deliverer do
       check_mailgun_message text_rails_message, basic_expected_mailgun_message.except(:html)
     end
 
+    it 'should include sender and recipient names in from field' do
+      check_mailgun_message text_rails_message_with_names, basic_expected_mailgun_message.except(:html).merge(emails_with_names)
+    end
+
     def check_mailgun_message(rails_message, mailgun_message)
       mailgun_client.should_receive(:send_message).with(mailgun_message)
       Mailgun::Deliverer.new(api_key: api_key, domain: domain).deliver!(rails_message)
@@ -58,6 +62,14 @@ describe Mailgun::Deliverer do
 
     def text_rails_message
       Mail::Message.new(common_rails_message_properties.merge(content_type: 'text/plain', body: text_body))
+    end
+
+    def text_rails_message_with_names
+      Mail::Message.new(common_rails_message_properties.merge(content_type: 'text/plain', body: text_body).merge(emails_with_names))
+    end
+
+    def emails_with_names
+      {from: ['Sender <from@email.com>'], to: ['Receiver <to@email.com>', 'Another one <to2@email.com>']}
     end
 
     def common_rails_message_properties


### PR DESCRIPTION
This PR ensures that when we send an email with from address like `Sender <from@example.com>`, the `Sender` name is preserved.
