### PR TITLE
Turns headers into mailgun params

### DIFF
--- a/lib/mailgun/deliverer.rb
+++ b/lib/mailgun/deliverer.rb
@@ -1,6 +1,17 @@
 module Mailgun
   class Deliverer
 
+    HEADERS = {
+      'X-Mailgun-Tag' => 'tag',
+      'X-Mailgun-Campaign-Id' => 'campaign',
+      'X-Mailgun-Dkim' => 'dkim',
+      'X-Mailgun-Deliver-By' => 'deliverytime',
+      'X-Mailgun-Drop-Message' => 'testmode',
+      'X-Mailgun-Track' => 'tracking',
+      'X-Mailgun-Track-Clicks' => 'tracking-clicks',
+      'X-Mailgun-Track-Opens' => 'tracking-opens',
+    }
+
     attr_accessor :settings
 
     def initialize(settings)
@@ -34,6 +45,7 @@ module Mailgun
       transform_mailgun_variables rails_message, mailgun_message
       transform_mailgun_recipient_variables rails_message, mailgun_message
       transform_custom_headers rails_message, mailgun_message
+      transform_mailgun_options rails_message, mailgun_message
     end
 
     def build_basic_mailgun_message_for(rails_message)
@@ -45,6 +57,27 @@ module Mailgun
       mailgun_message['h:Reply-To'] = rails_message[:reply_to].formatted.first
     end
 
+    def extract_custom_headers(rails_message)
+      mailgun_headers = rails_message.mailgun_headers || {}
+      rails_message.header_fields.each_with_object(mailgun_headers) do |field, headers|
+        headers[field.name] = field.value if field.name.start_with?('X-') && !field.name.start_with?('X-Mailgun')
+      end
+    end
+
+    def extract_options(rails_message)
+      mailgun_options = rails_message.mailgun_options || {}
+      rails_message.header_fields.each_with_object(mailgun_options) do |field, options|
+        options[HEADERS[field.name]] = field.value if HEADERS.has_key?(field.name)
+      end
+    end
+
+    def extract_recipient_variables(rails_message)
+      mailgun_recipient_variables = rails_message.mailgun_recipient_variables || {}
+      rails_message.header_fields.each_with_object(mailgun_recipient_variables) do |field, recipient_variables|
+        recipient_variables.merge field.value if field.name == 'X-Mailgun-Variables' && field.value.is_a?(Hash)
+      end
+    end
+    
     # @see http://stackoverflow.com/questions/4868205/rails-mail-getting-the-body-as-plain-text
     def extract_html(rails_message)
       if rails_message.html_part
@@ -62,6 +95,12 @@ module Mailgun
       end
     end
 
+    def transform_mailgun_options(rails_message, mailgun_message)
+      extract_options(rails_message).each do |name, value|
+        mailgun_message["o:#{name}"] = value
+      end
+    end
+
     def transform_mailgun_variables(rails_message, mailgun_message)
       rails_message.mailgun_variables.try(:each) do |name, value|
         mailgun_message["v:#{name}"] = value
@@ -69,13 +108,14 @@ module Mailgun
     end
 
     def transform_custom_headers(rails_message, mailgun_message)
-      rails_message.mailgun_headers.try(:each) do |name, value|
+      extract_custom_headers(rails_message).each do |name, value|
         mailgun_message["h:#{name}"] = value
       end
     end
 
     def transform_mailgun_recipient_variables(rails_message, mailgun_message)
-      mailgun_message['recipient-variables'] = rails_message.mailgun_recipient_variables.to_json if rails_message.mailgun_recipient_variables
+      mailgun_recipient_variables = extract_recipient_variables rails_message
+      mailgun_message['recipient-variables'] = mailgun_recipient_variables.to_json unless mailgun_recipient_variables.blank?
     end
 
     def remove_empty_values(mailgun_message)

--- a/lib/mailgun/mail_ext.rb
+++ b/lib/mailgun/mail_ext.rb
@@ -3,5 +3,6 @@ module Mail
     attr_accessor :mailgun_variables
     attr_accessor :mailgun_recipient_variables
     attr_accessor :mailgun_headers
+    attr_accessor :mailgun_options
   end
 end

--- a/spec/lib/mailgun/deliverer_spec.rb
+++ b/spec/lib/mailgun/deliverer_spec.rb
@@ -23,11 +23,17 @@ describe Mailgun::Deliverer do
     end
 
     it 'should invoke mailgun message transforming the custom headers' do
-      check_mailgun_message message_with_custom_headers, basic_expected_mailgun_message.merge('h:foo' => 'bar')
+      message = message_with_custom_headers
+      check_mailgun_message message, basic_expected_mailgun_message.merge('h:foo' => 'bar', 'h:X-baz' => 'qux')
     end
 
     it 'should invoke mailgun message transforming the recipient variables' do
       check_mailgun_message message_with_mailgun_recipient_variables, basic_expected_mailgun_message.merge('recipient-variables' => {foo: 'bar'}.to_json)
+    end
+
+    it 'should invoke mailgun message transforming on the options' do
+      message = message_with_options
+      check_mailgun_message message, basic_expected_mailgun_message.merge('o:campaign' => 1, 'o:tracking' => 'no')
     end
 
     it 'should send HTML only messages' do
@@ -99,6 +105,14 @@ describe Mailgun::Deliverer do
     def message_with_custom_headers
       message = basic_multipart_rails_message
       message.mailgun_headers = {foo: 'bar'}
+      message.headers({'X-baz' => 'qux'})
+      message
+    end
+
+    def message_with_options
+      message = basic_multipart_rails_message
+      message.mailgun_options = {campaign: 1}
+      message.headers({'X-Mailgun-Track' => 'no'})
       message
     end
 


### PR DESCRIPTION
This lets you use the [mailgun headers](http://documentation.mailgun.com/user_manual.html#sending-via-smtp) instead of using the additional hashes that mailgun_rails added on to `Mail::Message`.  I've also added the ability to set the [option params](http://documentation.mailgun.com/api-sending.html#sending).

It might make sense to deprecate the hashes and move over to using the headers since you can set the same value multiple times.  This is important for various options in mailgun like the `o:campaign` which can be set 3 times.  Of coarse this wouldn't be possible using the current client.  It would have to be moved over to using [`mailgun-ruby`](https://github.com/mailgun/mailgun-ruby).