### PR TITLE
Keeping the actual Mailgun id as a Mail::Message attribute.

### DIFF
--- a/lib/mailgun/deliverer.rb
+++ b/lib/mailgun/deliverer.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Mailgun
   class Deliverer
 
@@ -16,7 +18,9 @@ module Mailgun
     end
 
     def deliver!(rails_message)
-      mailgun_client.send_message build_mailgun_message_for(rails_message)
+      response = mailgun_client.send_message build_mailgun_message_for(rails_message)
+      response = JSON.parse(response)
+      rails_message.mailgun_id = response['id']
     end
 
     private

--- a/lib/mailgun/mail_ext.rb
+++ b/lib/mailgun/mail_ext.rb
@@ -4,5 +4,6 @@ module Mail
     attr_accessor :mailgun_options
     attr_accessor :mailgun_recipient_variables
     attr_accessor :mailgun_headers
+    attr_accessor :mailgun_id
   end
 end


### PR DESCRIPTION
I've made a change to keep the actual Mailgun message id.