### PR TITLE
Made mailgun_rails depend on actionmailer, not rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     mailgun_rails (0.6.6)
-      rails (>= 3.2.13)
+      actionmailer (>= 3.2.13)
+      json (>= 1.7.7)
       rest-client (>= 1.6.7)
 
 GEM
@@ -46,10 +47,14 @@ GEM
     arel (6.0.0)
     builder (3.2.2)
     diff-lcs (1.2.4)
+    domain_name (0.5.23)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     globalid (0.3.3)
       activesupport (>= 4.1.0)
     hike (1.2.3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.2)
     loofah (2.0.1)
@@ -60,7 +65,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.5.1)
     multi_json (1.10.1)
-    netrc (0.10.2)
+    netrc (0.10.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     rack (1.6.0)
@@ -91,7 +96,8 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
-    rest-client (1.7.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rspec (2.14.1)
@@ -117,11 +123,15 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   mailgun_rails!
+  rails (>= 3.2.13)
   rspec (~> 2.14.1)
   sqlite3

--- a/mailgun_rails.gemspec
+++ b/mailgun_rails.gemspec
@@ -17,9 +17,11 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 3.2.13"
+  s.add_dependency "actionmailer", ">= 3.2.13"
+  s.add_dependency "json", ">= 1.7.7"
   s.add_dependency "rest-client", ">= 1.6.7"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec", '~> 2.14.1'
+  s.add_development_dependency "rails", ">= 3.2.13"
 end


### PR DESCRIPTION
Previously, the gem was pulling in the rails gem as a dependency,
meaning that any project using mailgun_rails have all of the gems in
rails as dependencies too. That's an issue if you are not making a rails
app, or just want to keep your rails app as lean as possible.
mailgun_rails works fine with just actionmailer as a dependency, so I've
swapped rails for actionmailer and json as dependencies instead.