### PR TITLE
Made the default rake task run rspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,19 +14,10 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-
-
-
 Bundler::GemHelper.install_tasks
 
-require 'rake/testtask'
+require 'rspec/core/rake_task'
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << 'lib'
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
-  t.verbose = false
-end
+RSpec::Core::RakeTask.new(:spec)
 
-
-task default: :test
+task default: :spec

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -54,7 +54,7 @@ module Dummy
     # This will create an empty whitelist of attributes available for mass-assignment for all models
     # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
     # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = true
+    # config.active_record.whitelist_attributes = true
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -23,7 +23,7 @@ Dummy::Application.configure do
   config.action_dispatch.best_standards_support = :builtin
 
   # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
+  # config.active_record.mass_assignment_sanitizer = :strict
 
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -30,7 +30,7 @@ Dummy::Application.configure do
   config.action_mailer.delivery_method = :test
 
   # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
+  # config.active_record.mass_assignment_sanitizer = :strict
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
Right now travis isn't running any tests. At all. .travis.yml doesn't
specify any command to run, and so travis is doing the default action
(for a ruby project) and running ~bundle exec rake~. In the case of this
project, that runs test unit. Unfortunately, there aren't any test unit
tests, so nothing happens.

I've swapped out the test unit rake task for the default rspec one. This
should make tests run successfully on travis, but it's also good
practice for the default rake task to run tests.