### PR TITLE
Switched to the new (faster) travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+sudo: false
+cache: bundler
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Travis have started moving to a newer, faster infrastructure, but it's
opt-in. Details here:

http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

I've also enabled gem caching too. Hopefully this will make the travis
build faster.