### PR TITLE
Made travis test against all versions of rails

### DIFF
--- a/.gemfiles/rails3_2.gemfile
+++ b/.gemfiles/rails3_2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 3.2.0'
+
+gemspec path: '../'

--- a/.gemfiles/rails4_0.gemfile
+++ b/.gemfiles/rails4_0.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 4.0.0'
+
+gemspec path: '../'

--- a/.gemfiles/rails4_1.gemfile
+++ b/.gemfiles/rails4_1.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 4.1.0'
+
+gemspec path: '../'

--- a/.gemfiles/rails4_2.gemfile
+++ b/.gemfiles/rails4_2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 4.2.0'
+
+gemspec path: '../'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,13 @@ rvm:
   - 2.2
   - jruby
   - rbx
+matrix:
+  include:
+    - rvm: 2.2
+      gemfile: .gemfiles/rails3_2.gemfile
+    - rvm: 2.2
+      gemfile: .gemfiles/rails4_0.gemfile
+    - rvm: 2.2
+      gemfile: .gemfiles/rails4_1.gemfile
+    - rvm: 2.2
+      gemfile: .gemfiles/rails4_2.gemfile


### PR DESCRIPTION
Right now travis will only test against the latest version of rails.
This commit sets up multiple gemfiles, each with a different version of
rails, which travis will run against the latest version of ruby.