### PR TITLE
Upgraded to v3 api endpoint

### DIFF
--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -19,7 +19,7 @@ module Mailgun
     end
 
     def api_url
-      "https://api:#{api_key}@api.mailgun.net/v2/#{domain}"
+      "https://api:#{api_key}@api.mailgun.net/v3/#{domain}"
     end
   end
 end

--- a/spec/lib/mailgun/client_spec.rb
+++ b/spec/lib/mailgun/client_spec.rb
@@ -6,7 +6,7 @@ describe Mailgun::Client do
 
   describe "#send_message" do
     it 'should make a POST rest request passing the parameters to the mailgun end point' do
-      expected_url = "https://api:some_api_key@api.mailgun.net/v2/some_domain/messages"
+      expected_url = "https://api:some_api_key@api.mailgun.net/v3/some_domain/messages"
       RestClient.should_receive(:post).with(expected_url, foo: :bar)
       client.send_message foo: :bar
     end


### PR DESCRIPTION
Right now the gem is hard-coded to use the v2 api, but v3 is out.
According to mailgun, v3 is backwards compatible except for the bounces
endpoint, which the gem does not use (details here -
http://blog.mailgun.com/default-api-version-now-v3/).

This changes the (hard-coded) endpoint url from v2 to v3. Possibly
solving #34.