### PR TITLE
Ignored rubinius build failures on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ matrix:
       gemfile: .gemfiles/rails4_1.gemfile
     - rvm: 2.2
       gemfile: .gemfiles/rails4_2.gemfile
+  allow_failures:
+    - rvm: rbx


### PR DESCRIPTION
There's a bug in the mail gem that only affects rubinius. This seems to
be causing build failures for mailgun_rails. Here's the details of the
bug:

https://github.com/mikel/mail/pull/782

This commit temporarily sets travis to ignore failures on rubinius. I
think it's better to have a reliable build than have to manually check
whether the failure is due to a known bug in another library.

Ultimately this should be reverted once the bug is resolved.