### PR TITLE
Set message_id to the final value from mailgun response

### DIFF
--- a/lib/mailgun/deliverer.rb
+++ b/lib/mailgun/deliverer.rb
@@ -16,7 +16,12 @@ module Mailgun
     end
 
     def deliver!(rails_message)
-      mailgun_client.send_message build_mailgun_message_for(rails_message)
+      response = mailgun_client.send_message build_mailgun_message_for(rails_message)
+      if response.code == 200
+        mailgun_message_id = JSON.parse(response.to_str)["id"]
+        rails_message.message_id = mailgun_message_id
+      end
+      response
     end
 
     private

--- a/spec/lib/mailgun/deliverer_spec.rb
+++ b/spec/lib/mailgun/deliverer_spec.rb
@@ -108,8 +108,16 @@ describe Mailgun::Deliverer do
       check_mailgun_message rails_message, expectation
     end
 
+    it "should update the Mail::Message#message_id with the id returned from mailgun" do
+      msg = Mail::Message.new(to: 'to@email.com', from: 'from@email.com')
+      expectation = { to: ['to@email.com'], from: ['from@email.com']}
+      check_mailgun_message msg, expectation
+      msg.message_id.should eq "20111114174239.25659.5817@samples.mailgun.org"
+    end
+
     def check_mailgun_message(rails_message, mailgun_message)
-      mailgun_client.should_receive(:send_message).with(mailgun_message)
+      rest_response = double(:code => 200, :to_str => '{"message": "Queued. Thank you.","id": "<20111114174239.25659.5817@samples.mailgun.org>"}')
+      mailgun_client.should_receive(:send_message).with(mailgun_message).and_return(rest_response)
       Mailgun::Deliverer.new(api_key: api_key, domain: domain).deliver!(rails_message)
     end
 


### PR DESCRIPTION
The RestClient response from mailgun contains the actual Message-ID used in the sent email.  Copy this value back to Mail::Message so that it is available in the rails app, can be recorded and later associated associated with clicks and views.

This is not the same as setting the Message-ID, as was discussed in a different PR, but can have the same benefits (i.e. recording the actually Message-ID).

The example REST response used in the specs is straight from mailman's API documentation. The behavior has also been verified against mailgun's live API