### PR TITLE
verify_ssl option

### DIFF
--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -3,15 +3,21 @@ require 'rest_client'
 
 module Mailgun
   class Client
-    attr_reader :api_key, :domain
+    attr_reader :api_key, :domain, :verify_ssl
 
-    def initialize(api_key, domain)
+    def initialize(api_key, domain, verify_ssl = true)
       @api_key = api_key
       @domain = domain
+      @verify_ssl = verify_ssl
     end
 
     def send_message(options)
-      RestClient.post mailgun_url, options
+      RestClient::Request.execute(
+              method: :post,
+              url: mailgun_url,
+              payload: options,
+              verify_ssl: verify_ssl
+      )
     end
 
     def mailgun_url

--- a/lib/mailgun/deliverer.rb
+++ b/lib/mailgun/deliverer.rb
@@ -14,6 +14,11 @@ module Mailgun
     def api_key
       self.settings[:api_key]
     end
+    
+    def verify_ssl
+      #default value = true
+      self.settings[:verify_ssl] != false
+    end
 
     def deliver!(rails_message)
       mailgun_client.send_message build_mailgun_message_for(rails_message)
@@ -110,7 +115,7 @@ module Mailgun
     end
 
     def mailgun_client
-      @maingun_client ||= Client.new(api_key, domain)
+      @maingun_client ||= Client.new(api_key, domain, verify_ssl)
     end
   end
 end


### PR DESCRIPTION
When using mailgun from dev environment, i got this exception :
```ruby
    RestClient::SSLCertificateNotVerified (SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed):
```
In order to bypass this, in dev environment, we should make use of 'verify_ssl' params in RestClient

 With this pull request, we can add a verify_ssl option to the settings : 

```ruby
    #config/environments/development.rb
    Myapp::Application.configure do
      #...
      config.action_mailer.mailgun_settings = {
        api_key: ENV['MAILGUN_API_KEY'],
        domain: ENV['MAILGUN_DOMAIN'],
        verify_ssl: false
      }
      #...
    end
```