### PR TITLE
Custom sending domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ To provide option parameters like `o:campaign` or `o:tag`.
 email.mailgun_options = {campaign: '1'}
 ```
 
+### Sending from multiple domains
+
+Set the `domain` setting to `auto` to automatically set the Mailgun domain based on the from address.
+
+```ruby
+config.action_mailer.delivery_method = :mailgun
+config.action_mailer.mailgun_settings = {
+		api_key: '<mailgun api key>',
+		domain: :auto
+}
+```
+
 Pull requests are welcomed
-
-

--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -3,7 +3,8 @@ require 'rest_client'
 
 module Mailgun
   class Client
-    attr_reader :api_key, :domain
+    attr_reader :api_key
+    attr_accessor :domain
 
     def initialize(api_key, domain)
       @api_key = api_key

--- a/lib/mailgun/deliverer.rb
+++ b/lib/mailgun/deliverer.rb
@@ -16,7 +16,10 @@ module Mailgun
     end
 
     def deliver!(rails_message)
-      response = mailgun_client.send_message build_mailgun_message_for(rails_message)
+      client = mailgun_client
+      client.domain = extract_domain(rails_message) if domain.to_s == 'auto'
+      response = client.send_message build_mailgun_message_for(rails_message)
+
       if response.code == 200
         mailgun_message_id = JSON.parse(response.to_str)["id"]
         rails_message.message_id = mailgun_message_id
@@ -91,6 +94,10 @@ module Mailgun
       else
         rails_message.content_type =~ /text\/plain/ ? rails_message.body.decoded : nil
       end
+    end
+
+    def extract_domain(rails_message)
+      rails_message[:from].to_s.split("@").last
     end
 
     def transform_mailgun_variables(rails_message, mailgun_message)

--- a/lib/mailgun/deliverer.rb
+++ b/lib/mailgun/deliverer.rb
@@ -97,7 +97,7 @@ module Mailgun
     end
 
     def extract_domain(rails_message)
-      rails_message[:from].to_s.split("@").last
+      rails_message[:from].to_s[/@(.+?)>?\z/,1]
     end
 
     def transform_mailgun_variables(rails_message, mailgun_message)

--- a/spec/lib/mailgun/client_spec.rb
+++ b/spec/lib/mailgun/client_spec.rb
@@ -10,5 +10,12 @@ describe Mailgun::Client do
       RestClient.should_receive(:post).with(expected_url, foo: :bar)
       client.send_message foo: :bar
     end
+
+    it "should use custom set domain" do
+      expected_url = "https://api:some_api_key@api.mailgun.net/v3/email.com/messages"
+      RestClient.should_receive(:post).with(expected_url, foo: :bar)
+      client.domain = "email.com"
+      client.send_message foo: :bar
+    end
   end
 end

--- a/spec/lib/mailgun/deliverer_spec.rb
+++ b/spec/lib/mailgun/deliverer_spec.rb
@@ -124,6 +124,13 @@ describe Mailgun::Deliverer do
         expectation = { to: ['to@email.com'], from: ['from@email.com']}
         check_mailgun_message msg, expectation
       end
+
+      it "should auto detect domain when domain is more complex" do
+        msg = Mail::Message.new(to: 'to@email.com', from: 'My Name <from@email.com>')
+        mailgun_client.should_receive(:domain=).with("email.com")
+        expectation = { to: ['to@email.com'], from: ['My Name <from@email.com>']}
+        check_mailgun_message msg, expectation
+      end
     end
 
     def check_mailgun_message(rails_message, mailgun_message)

--- a/spec/lib/mailgun/deliverer_spec.rb
+++ b/spec/lib/mailgun/deliverer_spec.rb
@@ -115,6 +115,17 @@ describe Mailgun::Deliverer do
       msg.message_id.should eq "20111114174239.25659.5817@samples.mailgun.org"
     end
 
+    context "with domain on auto detect" do
+      let(:domain) { :auto }
+
+      it "should auto detect domain when domain is set to auto" do
+        msg = Mail::Message.new(to: 'to@email.com', from: 'from@email.com')
+        mailgun_client.should_receive(:domain=).with("email.com")
+        expectation = { to: ['to@email.com'], from: ['from@email.com']}
+        check_mailgun_message msg, expectation
+      end
+    end
+
     def check_mailgun_message(rails_message, mailgun_message)
       rest_response = double(:code => 200, :to_str => '{"message": "Queued. Thank you.","id": "<20111114174239.25659.5817@samples.mailgun.org>"}')
       mailgun_client.should_receive(:send_message).with(mailgun_message).and_return(rest_response)


### PR DESCRIPTION
See issue #54 

This allows setting the `domain` option to `auto` so the `Deliverer` will automatically set the domain based on the from address.

Any feedback is welcome.