### PR TITLE
Add a region option for selecting EU region

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ config.action_mailer.mailgun_settings = {
 		domain: '<mailgun domain>'
 }
 ```
+To select EU region add the `region: 'eu'` to `mailgun_settings`.
 
 Now you can send emails using plain Action Mailer:
 

--- a/lib/mailgun_rails/client.rb
+++ b/lib/mailgun_rails/client.rb
@@ -3,12 +3,13 @@ require 'rest_client'
 
 module MailgunRails
   class Client
-    attr_reader :api_key, :domain, :verify_ssl
+    attr_reader :api_key, :domain, :verify_ssl, :region
 
-    def initialize(api_key, domain, verify_ssl = true)
+    def initialize(api_key, domain, verify_ssl = true, region = nil)
       @api_key = api_key
       @domain = domain
       @verify_ssl = verify_ssl
+      @region = region && !region.to_s.strip.empty? ? ".#{region}" : ''
     end
 
     def send_message(options)
@@ -25,7 +26,7 @@ module MailgunRails
     end
 
     def api_url
-      "https://api:#{api_key}@api.mailgun.net/v3/#{domain}"
+      "https://api:#{api_key}@api#{region}.mailgun.net/v3/#{domain}"
     end
   end
 end

--- a/lib/mailgun_rails/deliverer.rb
+++ b/lib/mailgun_rails/deliverer.rb
@@ -20,6 +20,10 @@ module MailgunRails
       self.settings[:verify_ssl] != false
     end
 
+    def region
+      self.settings[:region]
+    end
+
     def deliver!(rails_message)
       response = mailgun_client.send_message build_mailgun_message_for(rails_message)
       if response.code == 200
@@ -126,7 +130,7 @@ module MailgunRails
     end
 
     def mailgun_client
-      @maingun_client ||= Client.new(api_key, domain, verify_ssl)
+      @maingun_client ||= Client.new(api_key, domain, verify_ssl, region)
     end
   end
 end


### PR DESCRIPTION
You can set a region in config
```
config.action_mailer.delivery_method = :mailgun
config.action_mailer.mailgun_settings = {
		api_key: '<mailgun api key>',
		domain: '<mailgun domain>',
		region: 'eu',
}
```